### PR TITLE
Fix cp with folder names containing spaces

### DIFF
--- a/action/dist/index.js
+++ b/action/dist/index.js
@@ -8285,7 +8285,7 @@ var writeToProcess = function (command, args, opts) { return new Promise(functio
                 folder = path.resolve(process.cwd(), config.folder);
                 console.log("##[info] Copying all files from " + folder);
                 // TODO: replace this copy with a node implementation
-                return [4 /*yield*/, exec("cp -rT " + folder + "/ ./", { env: env, cwd: REPO_TEMP })];
+                return [4 /*yield*/, exec("cp -rT \"" + folder + "\"/ ./", { env: env, cwd: REPO_TEMP })];
             case 26:
                 // TODO: replace this copy with a node implementation
                 _g.sent();

--- a/action/src/index.ts
+++ b/action/src/index.ts
@@ -404,7 +404,7 @@ const writeToProcess = (command: string, args: string[], opts: { env: { [id: str
   const folder = path.resolve(process.cwd(), config.folder);
   console.log(`##[info] Copying all files from ${folder}`);
   // TODO: replace this copy with a node implementation
-  await exec(`cp -rT ${folder}/ ./`, { env, cwd: REPO_TEMP });
+  await exec(`cp -rT "${folder}"/ ./`, { env, cwd: REPO_TEMP });
   await exec(`git add -A .`, { env, cwd: REPO_TEMP });
   const message =
     config.message


### PR DESCRIPTION
This fixes issue #32 by wrapping `cp` arguments with quotation marks.