### PR TITLE
fix: remove trailing newline of commit message

### DIFF
--- a/action/dist/index.js
+++ b/action/dist/index.js
@@ -12519,7 +12519,8 @@ const main = async ({ env = process.env, log, }) => {
             };
         }
         return {
-            commitMessage: commit.commit.message,
+            // Use trim to remove the trailing newline
+            commitMessage: commit.commit.message.trim(),
             sha: commit.oid,
         };
     };

--- a/action/src/index.ts
+++ b/action/src/index.ts
@@ -390,8 +390,8 @@ export const main = async ({
       };
     }
     return {
-      // Use slice to remove the trailing newline
-      commitMessage: commit.commit.message.slice(0, -1),
+      // Use trim to remove the trailing newline
+      commitMessage: commit.commit.message.trim(),
       sha: commit.oid,
     };
   };

--- a/action/src/index.ts
+++ b/action/src/index.ts
@@ -390,7 +390,8 @@ export const main = async ({
       };
     }
     return {
-      commitMessage: commit.commit.message,
+      // Use slice to remove the trailing newline
+      commitMessage: commit.commit.message.slice(0, -1),
       sha: commit.oid,
     };
   };


### PR DESCRIPTION
After having experimented with this action for a bit, I found `{msg} ({sha})` to be the commit message format I liked the most. However, there seemed to be a trailing newline at the end of the message, converting this example commit message:
![image](https://user-images.githubusercontent.com/66554238/151624161-bf737852-0094-44f4-8f9f-fd7324da58d5.png)
into this one instead:
![image](https://user-images.githubusercontent.com/66554238/151624181-dca5a285-ece1-4815-adc1-19183b102db5.png)

I've went through the `isomorphic-git` source, and found [this function](https://github.com/isomorphic-git/isomorphic-git/blob/main/src/utils/normalizeNewlines.js) which adds a single trailing newline on purpose. I think that it should be removed here though because it ruins the commit message and you can just add it back in your custom commit message if you need it.