### PR TITLE
bump node version to 20

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@main
       with:
-        node-version: 16.x
+        node-version: 20.x
     - run: |
         cd action
         npm install

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@main
       with:
-        node-version: 16.x
+        node-version: 20.x
     - name: 'Build'
       run: |
         cd action
@@ -26,7 +26,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@main
       with:
-        node-version: 16.x
+        node-version: 20.x
     - name: Install NPM Packages
       run: |
         cd action

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@main
       with:
-        node-version: 16.x
+        node-version: 20.x
     - name: npm install and build
       run: |
         npm install
@@ -155,7 +155,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@main
       with:
-        node-version: 16.x
+        node-version: 20.x
     - name: npm install and build
       run: |
         npm install

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ name: 'Push git subdirectory as branch'
 description: 'Push a subdirectory as a branch to any git repo over SSH (or to the local repo)'
 author: 'Sam Lanning <sam@samlanning.com>'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'action/dist/index.js'
 branding:
   icon: 'upload-cloud'


### PR DESCRIPTION
Bump node version to 20.

> _"Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: s0/git-publish-subdir-action@develop. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/."_