### PR TITLE
fix: Cleanup temporary directory

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -21,6 +21,8 @@ jobs:
   unit-tests:
     name: Run Unit Tests
     runs-on: ubuntu-latest
+    # do not run from forks, as forks don’t have access to repository secrets
+    if: github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login
     steps:
     - name: Install docker-compose
       run: sudo apt-get update && sudo apt-get install -y docker-compose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ jobs:
   deploy-ssh-no-branch:
     name: Test deploying to a new branch
     runs-on: ubuntu-latest
+    # do not run from forks, as forks don’t have access to repository secrets
+    if: github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login
     steps:
     - uses: actions/checkout@master
     - name: Setup Dummy Data
@@ -37,6 +39,8 @@ jobs:
   deploy-ssh-existing-branch:
     name: Test deploying to a pre-existing branch
     runs-on: ubuntu-latest
+    # do not run from forks, as forks don’t have access to repository secrets
+    if: github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login
     steps:
     - uses: actions/checkout@master
     - name: Setup Dummy Data
@@ -54,6 +58,8 @@ jobs:
   deploy-ssh-existing-branch-known_hosts:
     name: Test deploying to a pre-existing branch (with KNOWN_HOSTS_FILE)
     runs-on: ubuntu-latest
+    # do not run from forks, as forks don’t have access to repository secrets
+    if: github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login
     steps:
     - uses: actions/checkout@master
     - name: Setup Dummy Data
@@ -72,6 +78,8 @@ jobs:
   deploy-ssh-twice:
     name: Test deploying multiple times in one job
     runs-on: ubuntu-latest
+    # do not run from forks, as forks don’t have access to repository secrets
+    if: github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login
     steps:
     - uses: actions/checkout@master
     - name: Setup Dummy Data
@@ -99,6 +107,8 @@ jobs:
   deploy-locally:
     name: Test deploying to another branch of same repo
     runs-on: ubuntu-latest
+    # do not run from forks, as forks don’t have access to repository secrets
+    if: github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login
     steps:
     - uses: actions/checkout@master
     - name: Setup Dummy Data

--- a/action/dist/index.js
+++ b/action/dist/index.js
@@ -471,6 +471,8 @@ const main = async ({ env = process.env, log, }) => {
         log.log(`##[info] Killing ssh-agent`);
         await (0, exports.exec)(`ssh-agent -k`, { log, env: childEnv });
     }
+    log.log(`##[info] Removing temporary directory`);
+    await fs_1.promises.rm(TMP_PATH, { recursive: true });
 };
 exports.main = main;
 

--- a/action/src/index.ts
+++ b/action/src/index.ts
@@ -644,4 +644,7 @@ export const main = async ({
     log.log(`##[info] Killing ssh-agent`);
     await exec(`ssh-agent -k`, { log, env: childEnv });
   }
+
+  log.log(`##[info] Removing temporary directory`);
+  await fs.rm(TMP_PATH, { recursive: true });
 };


### PR DESCRIPTION
Remove temporary directory once the action completes, this is particularly relevant in the context of self-hosted runners in which the environment may persist between run.